### PR TITLE
Option to omit Extension creation

### DIFF
--- a/src/Postgres/src/PostgresDbClient.cs
+++ b/src/Postgres/src/PostgresDbClient.cs
@@ -25,16 +25,20 @@ public class PostgresDbClient
     /// </summary>
     /// <param name="connectionString">connection string</param>
     /// <param name="schema">schema name</param>
-    public PostgresDbClient(string connectionString, string schema)
+    public PostgresDbClient(string connectionString, string schema, bool omitExtensionCreation = false)
     {
         var dataSource = new NpgsqlDataSourceBuilder(connectionString).Build();
         var connection = dataSource.OpenConnection();
-        using (connection)
-        {
-            var command = connection.CreateCommand();
-            command.CommandText = "CREATE EXTENSION IF NOT EXISTS vector";
 
-            command.ExecuteNonQuery();
+        if (!omitExtensionCreation)
+        {
+            using (connection)
+            {
+                var command = connection.CreateCommand();
+                command.CommandText = "CREATE EXTENSION IF NOT EXISTS vector";
+    
+                command.ExecuteNonQuery();
+            }
         }
 
         var dataSourceBuilder = new NpgsqlDataSourceBuilder(connectionString);


### PR DESCRIPTION
Since not all DB admins like to share SU user roles to access applications we have made the creation of Extention optional

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional parameter to the `PostgresDbClient` constructor that allows users to skip the creation of database extensions, providing more flexibility during client instantiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->