### PR TITLE
Add SearchByMetadata method to SqlLiteVectorCollection

### DIFF
--- a/src/Abstractions/src/IVectorCollection.cs
+++ b/src/Abstractions/src/IVectorCollection.cs
@@ -58,6 +58,16 @@ public interface IVectorCollection
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Searches for records based on a metadata filter from a specific collection.
+    /// </summary>
+    /// <param name="filters">The filters to apply to the search request.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the search response.</returns>
+    Task<List<Vector>> SearchByMetadata(
+        Dictionary<string, object> filters,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Checks if the collection is empty.
     /// </summary>
     /// <param name="cancellationToken">The cancellation token.</param>

--- a/src/Chroma/src/ChromaVectorCollection.cs
+++ b/src/Chroma/src/ChromaVectorCollection.cs
@@ -169,7 +169,7 @@ public class ChromaVectorCollection(
 
     Task<List<Vector>> IVectorCollection.SearchByMetadata(Dictionary<string, object> filters, CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        throw new NotSupportedException("SemanticKernel doesn't support collection metadata");
     }
 }
 

--- a/src/Chroma/src/ChromaVectorCollection.cs
+++ b/src/Chroma/src/ChromaVectorCollection.cs
@@ -166,6 +166,11 @@ public class ChromaVectorCollection(
         return JsonSerializer.Deserialize(metadata.AdditionalMetadata, SourceGenerationContext.Default.IDictionaryStringObject)
                ?? new Dictionary<string, object>();
     }
+
+    Task<List<Vector>> IVectorCollection.SearchByMetadata(Dictionary<string, object> filters, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
 }
 
 [JsonSourceGenerationOptions(Converters = [typeof(ObjectAsPrimitiveConverter)])]

--- a/src/Elasticsearch/src/ElasticsearchVectorCollection.cs
+++ b/src/Elasticsearch/src/ElasticsearchVectorCollection.cs
@@ -103,4 +103,9 @@ public class ElasticsearchVectorCollection(
     {
         throw new NotImplementedException();
     }
+
+    Task<List<Vector>> IVectorCollection.SearchByMetadata(Dictionary<string, object> filters, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/src/InMemory/src/InMemoryVectorCollection.cs
+++ b/src/InMemory/src/InMemoryVectorCollection.cs
@@ -91,4 +91,9 @@ public class InMemoryVectorCollection(
     {
         return Task.FromResult(_vectors.GetValueOrDefault(id));
     }
+
+    Task<List<Vector>> IVectorCollection.SearchByMetadata(Dictionary<string, object> filters, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/src/Mongo/src/MongoVectorCollection.cs
+++ b/src/Mongo/src/MongoVectorCollection.cs
@@ -70,4 +70,9 @@ public class MongoVectorCollection(
             .ToArray(),
         };
     }
+
+    Task<List<Vector>> IVectorCollection.SearchByMetadata(Dictionary<string, object> filters, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/src/OpenSearch/src/OpenSearchVectorCollection.cs
+++ b/src/OpenSearch/src/OpenSearchVectorCollection.cs
@@ -133,4 +133,9 @@ public class OpenSearchVectorCollection(
     {
         throw new NotImplementedException();
     }
+
+    Task<List<Vector>> IVectorCollection.SearchByMetadata(Dictionary<string, object> filters, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/src/Postgres/src/PostgresVectorCollection.cs
+++ b/src/Postgres/src/PostgresVectorCollection.cs
@@ -1,3 +1,4 @@
+
 namespace LangChain.Databases.Postgres;
 
 /// <summary>
@@ -120,6 +121,11 @@ public class PostgresVectorCollection(
 
     /// <inheritdoc />
     public Task<bool> IsEmptyAsync(CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    Task<List<Vector>> IVectorCollection.SearchByMetadata(Dictionary<string, object> filters, CancellationToken cancellationToken)
     {
         throw new NotImplementedException();
     }

--- a/src/SemanticKernel/src/SemanticKernelMemoryStoreCollection.cs
+++ b/src/SemanticKernel/src/SemanticKernelMemoryStoreCollection.cs
@@ -75,4 +75,9 @@ public class SemanticKernelMemoryStoreCollection(IMemoryStore store,
             .ToListAsync(cancellationToken).ConfigureAwait(false);
         return new VectorSearchResponse { Items = results.Select(x => new Vector { Text = x.Item1.Metadata.ExternalSourceName }).ToList() };
     }
+
+    Task<List<Vector>> IVectorCollection.SearchByMetadata(Dictionary<string, object> filters, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/src/Sqlite/src/SqLiteVectorCollection.cs
+++ b/src/Sqlite/src/SqLiteVectorCollection.cs
@@ -37,49 +37,56 @@ public sealed class SqLiteVectorCollection : VectorCollection, IVectorCollection
 
     private async Task InsertDocument(string id, float[] vector, Vector document)
     {
-        var insertCommand = _connection.CreateCommand();
-        string query = $"INSERT INTO {Name} (id, vector, document) VALUES (@id, @vector, @document)";
-        insertCommand.CommandText = query;
-        insertCommand.Parameters.AddWithValue("@id", id);
-        insertCommand.Parameters.AddWithValue("@vector", SerializeVector(vector));
-        insertCommand.Parameters.AddWithValue("@document", SerializeDocument(document));
-        await insertCommand.ExecuteNonQueryAsync().ConfigureAwait(false);
-
+        using (var insertCommand = _connection.CreateCommand())
+        {
+            string query = $"INSERT INTO {Name} (id, vector, document) VALUES (@id, @vector, @document)";
+            insertCommand.CommandText = query;
+            insertCommand.Parameters.AddWithValue("@id", id);
+            insertCommand.Parameters.AddWithValue("@vector", SerializeVector(vector));
+            insertCommand.Parameters.AddWithValue("@document", SerializeDocument(document));
+            await insertCommand.ExecuteNonQueryAsync().ConfigureAwait(false);
+        }
     }
 
     private async Task DeleteDocument(string id)
     {
-        var deleteCommand = _connection.CreateCommand();
-        string query = $"DELETE FROM {Name} WHERE id=@id";
-        deleteCommand.CommandText = query;
-        deleteCommand.Parameters.AddWithValue("@id", id);
-        await deleteCommand.ExecuteNonQueryAsync().ConfigureAwait(false);
+        using (var deleteCommand = _connection.CreateCommand())
+        {
+            string query = $"DELETE FROM {Name} WHERE id=@id";
+            deleteCommand.CommandText = query;
+            deleteCommand.Parameters.AddWithValue("@id", id);
+            await deleteCommand.ExecuteNonQueryAsync().ConfigureAwait(false);
+        }
     }
 
     private async Task<List<(Vector, float)>> SearchByVector(float[] vector, int k)
     {
-        var searchCommand = _connection.CreateCommand();
-        string query = $"SELECT id, vector, document, distance(vector, @vector) d FROM {Name} ORDER BY d LIMIT @k";
-        searchCommand.CommandText = query;
-        searchCommand.Parameters.AddWithValue("@vector", SerializeVector(vector));
-        searchCommand.Parameters.AddWithValue("@k", k);
-        var res = new List<(Vector, float)>();
-        var reader = await searchCommand.ExecuteReaderAsync().ConfigureAwait(false);
-        while (await reader.ReadAsync().ConfigureAwait(false))
+        using (var searchCommand = _connection.CreateCommand())
         {
-            var id = reader.GetString(0);
-            var vec = await reader.GetFieldValueAsync<string>(1).ConfigureAwait(false);
-            var doc = await reader.GetFieldValueAsync<string>(2).ConfigureAwait(false);
-            var docDeserialized = JsonSerializer.Deserialize(doc, SourceGenerationContext.Default.Vector) ?? new Vector
+            string query = $"SELECT id, vector, document, distance(vector, @vector) d FROM {Name} ORDER BY d LIMIT @k";
+            searchCommand.CommandText = query;
+            searchCommand.Parameters.AddWithValue("@vector", SerializeVector(vector));
+            searchCommand.Parameters.AddWithValue("@k", k);
+            var res = new List<(Vector, float)>();
+
+            using (var reader = await searchCommand.ExecuteReaderAsync().ConfigureAwait(false))
             {
-                Text = string.Empty,
-            };
-            var distance = reader.GetFloat(3);
-            res.Add((docDeserialized, distance));
+                while (await reader.ReadAsync().ConfigureAwait(false))
+                {
+                    var id = reader.GetString(0);
+                    var vec = await reader.GetFieldValueAsync<string>(1).ConfigureAwait(false);
+                    var doc = await reader.GetFieldValueAsync<string>(2).ConfigureAwait(false);
+                    var docDeserialized = JsonSerializer.Deserialize(doc, SourceGenerationContext.Default.Vector) ?? new Vector
+                    {
+                        Text = string.Empty,
+                    };
+                    var distance = reader.GetFloat(3);
+                    res.Add((docDeserialized, distance));
+                }
 
+                return res;
+            }
         }
-
-        return res;
     }
 
     /// <inheritdoc />
@@ -109,41 +116,48 @@ public sealed class SqLiteVectorCollection : VectorCollection, IVectorCollection
     /// <inheritdoc />
     public async Task<Vector?> GetAsync(string id, CancellationToken cancellationToken = default)
     {
-        var command = _connection.CreateCommand();
-        var query = $"SELECT vector, document FROM {Name} WHERE id=@id";
-        command.CommandText = query;
-        command.Parameters.AddWithValue("@id", id);
-        var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        using (var command = _connection.CreateCommand())
         {
-            return null;
+            var query = $"SELECT vector, document FROM {Name} WHERE id=@id";
+            command.CommandText = query;
+            command.Parameters.AddWithValue("@id", id);
+
+            using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+            {
+                if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    return null;
+                }
+
+                var vec = await reader.GetFieldValueAsync<string>(0, cancellationToken).ConfigureAwait(false);
+                var doc = await reader.GetFieldValueAsync<string>(1, cancellationToken).ConfigureAwait(false);
+                var docDeserialized = JsonSerializer.Deserialize(doc, SourceGenerationContext.Default.Vector) ?? new Vector
+                {
+                    Text = string.Empty,
+                };
+
+                return new Vector
+                {
+                    Id = id,
+                    Text = docDeserialized.Text,
+                    Metadata = docDeserialized.Metadata,
+                    Embedding = JsonSerializer.Deserialize(vec, SourceGenerationContext.Default.SingleArray),
+                };
+            }
         }
-
-        var vec = await reader.GetFieldValueAsync<string>(0, cancellationToken).ConfigureAwait(false);
-        var doc = await reader.GetFieldValueAsync<string>(1, cancellationToken).ConfigureAwait(false);
-        var docDeserialized = JsonSerializer.Deserialize(doc, SourceGenerationContext.Default.Vector) ?? new Vector
-        {
-            Text = string.Empty,
-        };
-
-        return new Vector
-        {
-            Id = id,
-            Text = docDeserialized.Text,
-            Metadata = docDeserialized.Metadata,
-            Embedding = JsonSerializer.Deserialize(vec, SourceGenerationContext.Default.SingleArray),
-        };
     }
 
     /// <inheritdoc />
     public async Task<bool> IsEmptyAsync(CancellationToken cancellationToken = default)
     {
-        var command = _connection.CreateCommand();
-        var query = $"SELECT COUNT(*) FROM {Name}";
-        command.CommandText = query;
-        var count = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        using (var command = _connection.CreateCommand())
+        {
+            var query = $"SELECT COUNT(*) FROM {Name}";
+            command.CommandText = query;
+            var count = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
 
-        return count == null || Convert.ToInt32(count, CultureInfo.InvariantCulture) == 0;
+            return count == null || Convert.ToInt32(count, CultureInfo.InvariantCulture) == 0;
+        }
     }
 
     /// <inheritdoc />
@@ -179,5 +193,58 @@ public sealed class SqLiteVectorCollection : VectorCollection, IVectorCollection
                 Distance = d.Item2,
             }).ToArray(),
         };
+    }
+
+    /// <inheritdoc />
+    public async Task<List<Vector>> SearchByMetadata(
+    Dictionary<string, object> filters,
+    CancellationToken cancellationToken = default)
+    {
+        filters = filters ?? throw new ArgumentNullException(nameof(filters));
+
+        using (var command = _connection.CreateCommand())
+        {
+            var query = $"SELECT id, vector, document FROM {Name}";
+
+            var whereClauses = new List<string>();
+            int paramIndex = 0;
+
+            foreach (var filter in filters)
+            {
+                var paramName = "@param" + paramIndex++;
+                whereClauses.Add($"json_extract(document, '$.Metadata.{filter.Key}') = {paramName}");
+                command.Parameters.AddWithValue(paramName, filter.Value);
+            }
+            query += " WHERE " + string.Join(" AND ", whereClauses);
+
+            command.CommandText = query;
+            var res = new List<Vector>();
+
+            using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+            {
+                while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    var id = await reader.GetFieldValueAsync<string>(0, cancellationToken).ConfigureAwait(false);
+                    var vec = await reader.GetFieldValueAsync<string>(1, cancellationToken).ConfigureAwait(false);
+                    var doc = await reader.GetFieldValueAsync<string>(2, cancellationToken).ConfigureAwait(false);
+                    var docDeserialized = JsonSerializer.Deserialize(doc, SourceGenerationContext.Default.Vector) ?? new Vector
+                    {
+                        Text = string.Empty,
+                    };
+
+                    var vector = new Vector
+                    {
+                        Id = id,
+                        Text = docDeserialized.Text,
+                        Metadata = docDeserialized.Metadata,
+                        Embedding = JsonSerializer.Deserialize(vec, SourceGenerationContext.Default.SingleArray),
+                    };
+
+                    res.Add(vector);
+                }
+
+                return res;
+            }
+        }
     }
 }


### PR DESCRIPTION
I appreciate that I've had to do a lot of NotImplementedExceptions to get this in - I will fix some of them, but I think some of the databases don't support metadata.

I didn't update the PublicAPI.txt doc as have not seem this before. 

I did also update some of the commands and readers in the other methods to be in a using block so they are disposed properly. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `SearchByMetadata` method across multiple vector collection implementations, allowing for future searches based on metadata filters.
	- Enhanced resource management in `SqLiteVectorCollection` with improved disposal practices for database commands.

- **Bug Fixes**
	- Added null checks for parameters in existing methods to improve error handling.

These updates will provide users with more flexible searching capabilities and improved reliability in database interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->