### PR TITLE
Add metadata search to mongodb

### DIFF
--- a/src/IntegrationTests/DatabaseTests.cs
+++ b/src/IntegrationTests/DatabaseTests.cs
@@ -298,10 +298,10 @@ public partial class DatabaseTests
     }
 
     [TestCase(SupportedDatabase.InMemory)]
-    //[TestCase(SupportedDatabase.Chroma)]
     //[TestCase(SupportedDatabase.OpenSearch)]
     //[TestCase(SupportedDatabase.Postgres)]
     [TestCase(SupportedDatabase.SqLite)]
+    [TestCase(SupportedDatabase.Mongo)]
     //[TestCase(SupportedDatabase.DuckDb)]
     //[TestCase(SupportedDatabase.Weaviate)]
     //[TestCase(SupportedDatabase.Elasticsearch)]

--- a/src/Mongo/src/MongoVectorCollection.cs
+++ b/src/Mongo/src/MongoVectorCollection.cs
@@ -11,7 +11,7 @@ public class MongoVectorCollection(
     string? id = null)
 : VectorCollection(name, id), IVectorCollection
 {
-    private IMongoCollection<Vector> _mongoCollection = mongoContext.GetCollection<Vector>(name);
+    private readonly IMongoCollection<Vector> _mongoCollection = mongoContext.GetCollection<Vector>(name);
 
     public async Task<IReadOnlyCollection<string>> AddAsync(IReadOnlyCollection<Vector> items, CancellationToken cancellationToken = default)
     {
@@ -80,6 +80,11 @@ public class MongoVectorCollection(
 
         foreach (var kvp in filters)
         {
+            if (kvp.Value == null)
+            {
+                throw new ArgumentException($"Metadata value for key '{kvp.Key}' cannot be null", nameof(filters));
+            }
+
             // Assuming your Vector class has a Metadata field of type Dictionary<string, object>
             var filter = builder.Eq($"Metadata.{kvp.Key}", kvp.Value);
             filterDefinitions.Add(filter);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the `SearchByMetadata` method in the MongoVectorCollection for improved accessibility and functionality.
	- Added support for testing against the MongoDB database in the `MetadataSearch_Ok` test case.

- **Bug Fixes**
	- Implemented error handling in the `SearchByMetadata` method for null filters.

- **Documentation**
	- Updated test cases to reflect changes in database support, including the addition of a new test case for null filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->