### PR TITLE
feat: allow user to provide client for OpenSearchVectorDatabase

### DIFF
--- a/src/OpenSearch/src/OpenSearchVectorCollection.cs
+++ b/src/OpenSearch/src/OpenSearchVectorCollection.cs
@@ -7,7 +7,7 @@ namespace LangChain.Databases.OpenSearch;
 /// Represents a vector collection using OpenSearch.
 /// </summary>
 public class OpenSearchVectorCollection(
-    OpenSearchClient client,
+    IOpenSearchClient client,
     string name,
     string id) : VectorCollection(name, id), IVectorCollection
 {

--- a/src/OpenSearch/src/OpenSearchVectorDatabase.cs
+++ b/src/OpenSearch/src/OpenSearchVectorDatabase.cs
@@ -7,7 +7,7 @@ namespace LangChain.Databases.OpenSearch;
 /// </summary>
 public class OpenSearchVectorDatabase : IVectorDatabase
 {
-    private readonly OpenSearchClient _client;
+    private readonly IOpenSearchClient _client;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OpenSearchVectorDatabase"/> class.
@@ -29,7 +29,7 @@ public class OpenSearchVectorDatabase : IVectorDatabase
     /// Initializes a new instance of the <see cref="OpenSearchVectorDatabase"/> class.
     /// </summary>
     /// <param name="client">The OpenSearch client.</param>
-    public OpenSearchVectorDatabase(OpenSearchClient client)
+    public OpenSearchVectorDatabase(IOpenSearchClient client)
     {
         _client = client;
     }

--- a/src/OpenSearch/src/OpenSearchVectorDatabase.cs
+++ b/src/OpenSearch/src/OpenSearchVectorDatabase.cs
@@ -25,6 +25,15 @@ public class OpenSearchVectorDatabase : IVectorDatabase
         _client = new OpenSearchClient(settings);
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OpenSearchVectorDatabase"/> class.
+    /// </summary>
+    /// <param name="client">The OpenSearch client.</param>
+    public OpenSearchVectorDatabase(OpenSearchClient client)
+    {
+        _client = client;
+    }
+
     /// <inheritdoc />
     public async Task CreateCollectionAsync(string collectionName, int dimensions, CancellationToken cancellationToken = default)
     {


### PR DESCRIPTION
I made two small commits. The first adds a constructor so that a user can pass in a preconfigured OpenSearchClient. This allows users to us other configurations instead of being forced to use simple authentication for OpenSearch.

The second commit simply changes all references to `OpenSearchClient` to the interface `IOpenSearchClient` for greater flexibility. If this is not desired for some reason, I can undo it.

I am working on an application that would benefit from these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the client integration to use a more flexible interface, which enhances overall integration options and improves testability while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->