### PR TITLE
fix: remove index.knn.space_type setting

### DIFF
--- a/src/OpenSearch/src/OpenSearchVectorDatabase.cs
+++ b/src/OpenSearch/src/OpenSearchVectorDatabase.cs
@@ -40,7 +40,6 @@ public class OpenSearchVectorDatabase : IVectorDatabase
         var response = await _client.Indices.CreateAsync(collectionName, c => c
             .Settings(x => x
                 .Setting("index.knn", true)
-                .Setting("index.knn.space_type", "cosinesimil")
             )
             .Map<VectorRecord>(m => m
                 .Properties(p => p


### PR DESCRIPTION
This "index.knn.space_type" setting is no longer available in opensearch 3. Rather than creating the index, it throws an exception.  Cosine Similarity was already being specified in the mapping, so the setting was not required in older versions anyway. I removed the offending line to restore functionality for version 3 of opensearch.